### PR TITLE
add get_streetview_image_by_coordinate api

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from langserve import add_routes
 from lib.penetrator import get_estate_info_by_coordinate
 from lib.geojson_to_img import geojson_to_img
 from lib.chain.nobushi import nobushi_chain
+from lib.streetview_image import get_streetview_image_by_coordinate
 
 
 load_dotenv()
@@ -81,6 +82,29 @@ async def geojson_png(request: Request):
     img_bytes = img_byte_arr.getvalue()
 
     # バイナリデータをレスポンスとして返す
+    return Response(content=img_bytes, media_type="image/png")
+
+
+@app.post("/streetview_png")
+@app.get("/streetview_png")
+async def streetview_png(request: Request):
+    """
+    緯度経度を受け取り、ストリートビュー画像を返す。
+    """
+    if request.method == "POST":
+        req_json = await request.json()
+        lat = req_json.get("lat", "")
+        lon = req_json.get("lon", "")
+    else:
+        lat = request.query_params.get("lat", "")
+        lon = request.query_params.get("lon", "")
+
+    if not lat or not lon:
+        return {"error": "lat, lon are required"}
+
+    # ストリートビュー画像を取得
+    img_bytes = get_streetview_image_by_coordinate(lat, lon)
+
     return Response(content=img_bytes, media_type="image/png")
 
 

--- a/backend/app/test_main.py
+++ b/backend/app/test_main.py
@@ -75,3 +75,10 @@ def test_geojson_png_get():
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
     assert response.content is not None
+
+
+def test_streetview_image_get():
+    response = client.get("/streetview_png", params={"lat": 35.6983223, "lon": 139.7730186})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.content is not None

--- a/backend/lib/streetview_image.py
+++ b/backend/lib/streetview_image.py
@@ -1,0 +1,35 @@
+import requests
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_KEY = os.getenv("GOOGLE_API_KEY")
+API_URL = "https://maps.googleapis.com/maps/api/streetview"
+
+
+def get_streetview_image_by_coordinate(lat: float, lon: float, size: str = "640x400", heading: int = 90, pitch: int = 0, fov: int = 90) -> bytes:
+    """
+    緯度経度を指定してStreet Viewの画像を取得する。
+
+    Args:
+        lat: 緯度
+        lon: 経度
+        size: 画像サイズ (例: "640x400")
+        heading: 水平方向のカメラ角度 (0-360)
+        pitch: 垂直方向のカメラ角度 (-90-90)
+        fov: 視野 (1-120)
+
+    Returns:
+        画像データ (バイト列)。
+    """
+    params = {
+        "size": size,
+        "location": f"{lat},{lon}",
+        "heading": heading,
+        "pitch": pitch,
+        "fov": fov,
+        "key": API_KEY,
+    }
+    response = requests.get(API_URL, params=params)
+    return response.content


### PR DESCRIPTION
This pull request introduces a new feature to retrieve and serve street view images based on latitude and longitude coordinates. The changes involve adding a new endpoint, implementing the functionality to fetch the images, and including tests for the new feature.

New feature implementation:

* [`backend/app/main.py`](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R15): Added a new import for `get_streetview_image_by_coordinate` and implemented the `streetview_png` endpoint to handle both POST and GET requests. This endpoint retrieves street view images based on provided latitude and longitude coordinates. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R15) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R88-R110)

Supporting functionality:

* [`backend/lib/streetview_image.py`](diffhunk://#diff-2446288c5954dd72ead8d5c5685a5af0be18dbebd7e835495768f1f430b583d1R1-R35): Implemented the `get_streetview_image_by_coordinate` function to fetch street view images from the Google Street View API using the provided coordinates and other optional parameters.

Testing:

* [`backend/app/test_main.py`](diffhunk://#diff-a3bb1dc84aa08834d143deef237a7064cfe8a28a6f4944766b2404725a6a6620R78-R84): Added a test case `test_streetview_image_get` to verify that the new `streetview_png` endpoint returns a valid image response when queried with latitude and longitude parameters.