### PR TITLE
型エラーなのに動くんかーーーーーーーーーーーーーい

### DIFF
--- a/frontend/src/components/NobushiRegionalMap/index.tsx
+++ b/frontend/src/components/NobushiRegionalMap/index.tsx
@@ -17,6 +17,7 @@ import {
   FeatureCollection,
   MultiPolygon,
   Polygon,
+  Geometry,
   GeoJsonProperties,
 } from "geojson";
 
@@ -90,13 +91,16 @@ export const NobushiRegionalMap: React.FC<{
           ),
         } as FeatureCollection<Polygon | MultiPolygon, GeoJsonProperties>;
         console.log(`newGeoJson:`, newGeoJson);
+        if (newGeoJson.features === undefined) {
+          console.error(`newGeoJson.features is undefined`);
+          return;
+        }
 
         // 海領域を除外する処理
         if (landMask && newGeoJson) {
-          const clipped = turf.intersect(
-            landMask,
-            newGeoJson as FeatureCollection<Polygon | MultiPolygon>
-          );
+          // `turf.mask` に正しい型を渡す
+          const clipped = turf.intersect(landMask, newGeoJson);
+
           console.log(clipped);
           if (!clipped) {
             console.error("clipped is undefined");

--- a/frontend/src/components/NobushiRegionalMap/index.tsx
+++ b/frontend/src/components/NobushiRegionalMap/index.tsx
@@ -10,6 +10,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { getOverpassResponseJsonWithCache } from "../../lib/osm/getOverpass";
 import { overpassQueriesForRegions } from "../../lib/osm/overpassQueries/overpassQueriesForRegions";
 import osmtogeojson from "osmtogeojson";
+import * as turf from "@turf/turf";
 import { fitBoundsToGeoJson } from "../../lib/maplibre/fitBoundsToGeoJson";
 
 export const NobushiRegionalMap: React.FC<{
@@ -18,9 +19,47 @@ export const NobushiRegionalMap: React.FC<{
 }> = ({ region, attributionPosition }) => {
   const mapRef = useRef<MapRef | null>(null);
 
-  const [geoJson, setGeoJson] = useState<GeoJSON.FeatureCollection | undefined>(
-    undefined
-  );
+  const [geoJson, setGeoJson] = useState<
+    | GeoJSON.FeatureCollection<
+        GeoJSON.Polygon | GeoJSON.MultiPolygon,
+        GeoJSON.GeoJsonProperties
+      >
+    | undefined
+  >(undefined);
+
+  const [landMask, setLandMask] = useState<
+    | GeoJSON.FeatureCollection<
+        GeoJSON.Polygon | GeoJSON.MultiPolygon,
+        GeoJSON.GeoJsonProperties
+      >
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    // 日本列島マスクデータのロード
+    const loadLandMask = async () => {
+      const response = await fetch(
+        "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/ne_10m_admin_1_states_provinces.geojson"
+      );
+      const data = await response.json();
+      // 日本の都道府県だけを抽出
+      const japanLand = {
+        type: "FeatureCollection",
+        features: data.features.filter(
+          (feature: GeoJSON.Feature) =>
+            feature.properties?.admin === "Japan" &&
+            (feature.geometry.type === "Polygon" ||
+              feature.geometry.type === "MultiPolygon")
+        ),
+      } as GeoJSON.FeatureCollection<
+        GeoJSON.Polygon | GeoJSON.MultiPolygon,
+        GeoJSON.GeoJsonProperties
+      >;
+      console.log(japanLand);
+      setLandMask(japanLand);
+    };
+    loadLandMask();
+  }, []);
 
   useEffect(() => {
     const doit = async () => {
@@ -37,12 +76,45 @@ export const NobushiRegionalMap: React.FC<{
           console.error(`overpassRes is undefined for region: ${region}`);
           return;
         }
-        const newGeoJson = osmtogeojson(overpassRes);
-        setGeoJson(newGeoJson);
+        const newOsmGeoJson = osmtogeojson(overpassRes);
+        const newGeoJson = turf.featureCollection(
+          newOsmGeoJson.features
+            .filter((feature) => {
+              return (
+                feature.geometry?.type === "Polygon" ||
+                feature.geometry?.type === "MultiPolygon"
+              );
+            })
+            .filter((feature) => !!feature.properties)
+        ) as GeoJSON.FeatureCollection<
+          GeoJSON.Polygon | GeoJSON.MultiPolygon,
+          GeoJSON.GeoJsonProperties
+        >;
+
+        // 海領域を除外する処理
+        if (landMask && newGeoJson) {
+          // landMaskとnewGeoJsonの交差部分を取得
+          // turf.intersect()はFeatureCollection同士の交差判定を行う
+          const clipped = turf.intersect(landMask, newGeoJson);
+          const clippedFeatureCollection = {
+            type: "FeatureCollection",
+            features: clipped
+              ? Array.isArray(clipped)
+                ? clipped
+                : [clipped]
+              : [],
+          } as GeoJSON.FeatureCollection<
+            GeoJSON.Polygon | GeoJSON.MultiPolygon,
+            GeoJSON.GeoJsonProperties
+          >;
+          setGeoJson(clippedFeatureCollection);
+        } else {
+          setGeoJson(newGeoJson);
+        }
       }
     };
     doit();
-  }, [region]);
+  }, [region, landMask]);
 
   useEffect(() => {
     if (geoJson) {

--- a/frontend/src/lib/osm/overpassQueries/overpassQueriesForRegions.ts
+++ b/frontend/src/lib/osm/overpassQueries/overpassQueriesForRegions.ts
@@ -120,11 +120,12 @@ out geom;
 `,
   },
   {
-    region: "東京都",
+    region: "東京都台東区",
     capital: true,
     query: `
 [out:json];
-relation["name"="東京都"]["admin_level"="4"];
+area["name"="東京都"]["admin_level"="4"];
+relation["name"="台東区"]["admin_level"="7"];
 out geom;
 `,
   },

--- a/frontend/src/pages/RelocatePage.tsx
+++ b/frontend/src/pages/RelocatePage.tsx
@@ -155,6 +155,7 @@ export const RelocatePage: React.FC = () => {
             {[area1, area2, area3, area4].map((area, idx) => {
               return (
                 <div
+                  key={`area-${area}-${idx}`}
                   style={{
                     position: "relative",
                     height: "100%",


### PR DESCRIPTION
This pull request includes several changes to the `NobushiRegionalMap` component and related files to improve the handling of geographic data and enhance the user experience. The most important changes include the addition of a land mask for Japan, filtering of geoJSON features, and improvements to the Overpass API queries.

Improvements to geographic data handling:

* [`frontend/src/components/NobushiRegionalMap/index.tsx`](diffhunk://#diff-bc400aa18201d928261ef4bbe69c37e44050e122b83c5dd4e670c9935356210cR13-R71): Added imports for `@turf/turf` and `geojson` types, and implemented a land mask to exclude sea regions from the displayed geoJSON data.
* [`frontend/src/components/NobushiRegionalMap/index.tsx`](diffhunk://#diff-bc400aa18201d928261ef4bbe69c37e44050e122b83c5dd4e670c9935356210cL40-R138): Modified the geoJSON processing to filter out non-polygon features and to intersect with the land mask to exclude sea regions.

Enhancements to Overpass API queries:

* [`frontend/src/lib/osm/overpassQueries/overpassQueriesForRegions.ts`](diffhunk://#diff-b8ea4cf6a956911119ce3579ac8dcc94941dbac998fcd723b23fb3c993df8943L123-R128): Updated the Overpass query for the Tokyo region to be more specific by including the "台東区" (Taito Ward) area.

Other improvements:

* [`frontend/src/pages/RelocatePage.tsx`](diffhunk://#diff-64c2e66cd176c8a664d6aaae6b74e24a340533396c12bd7ca8bdf1bcf782d91eR158): Added a `key` attribute to the map function to improve React's rendering performance.